### PR TITLE
Migrate tests to elm-check 3

### DIFF
--- a/Parser/Number.elm
+++ b/Parser/Number.elm
@@ -7,24 +7,27 @@ module Parser.Number (digit, natural, integer, float, sign) where
 -}
 
 import Char
-import Parser exposing (..)
 import List
+import Maybe exposing (withDefault)
+import Parser exposing (..)
+import Result exposing (toMaybe)
+import String
 
 {-| Parse a digit -}
 digit : Parser Int
 digit =
-    satisfy Char.isDigit 
+    satisfy Char.isDigit
     |> map (\x -> Char.toCode x - 48)
 
 {-| Parse a natural number -}
 natural : Parser Int
-natural = 
+natural =
     some digit
     |> map (List.foldl (\b a -> a * 10 + b) 0 )
 
 {-| Parse a optional sign, succeeds with a -1 if it matches a minus `Char`, otherwise it returns 1 -}
 sign : Parser Int
-sign = 
+sign =
     let plus = always (-1) `map` symbol '-'
         min  = always 1 `map` symbol '+'
     in  optional (plus `or` min) 1
@@ -32,11 +35,18 @@ sign =
 {-| Parse an integer with optional sign -}
 integer : Parser Int
 integer =
-    map (\sig nat -> sig * nat) sign `and` natural
+    map (*) sign `and` natural
+
+{-| The fromOk function extracts the element out of a Ok, with a default. -}
+fromOk : a -> Result e a -> a
+fromOk d = withDefault d << toMaybe
 
 {-| Parse a float with optional sign -}
 float : Parser Float
 float =
-    let convertToFloat sig int dig = toFloat sig * (toFloat int + 0.1 * List.foldr (\b a -> a / 10 + b) 0 (List.map toFloat dig))
+    let toFloatString (i,ds) =
+          toString i ++ "." ++ String.concat (List.map toString ds)
+        convertToFloat sig int digs =
+          toFloat sig * (fromOk 0.0 << String.toFloat << toFloatString) (int,digs)
     in
         map convertToFloat sign `and` integer `and` (symbol '.' *> some digit)

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,10 @@
         "Parser.Number"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.1 <= v < 2.0.2",
+        "TheSeamau5/elm-check": "3.2.0 <= v < 4.0.0",
+        "TheSeamau5/elm-shrink": "2.2.1 <= v < 3.0.0",
+        "circuithub/elm-result-extra": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "2.1.0 <= v < 2.2.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"


### PR DESCRIPTION
After migrating the tests to latest elm-check (3), I've found a failure related to the float parser when dealing with 0. I suspect we need to use `0.0` instead of `0` when generating the floats for the property test but wanted to check with you first.

![screenshot from 2015-06-05 23 04 06](https://cloud.githubusercontent.com/assets/887937/8018261/ac9f75f6-0bd7-11e5-88cd-fa6c4e62a904.png)

Would you mind helping me out with this issue?

Besides that, I had to download [Shrink.elm](https://raw.githubusercontent.com/TheSeamau5/elm-shrink/master/src/Shrink.elm) to be able to compile even though it's already downloaded as a dependency. I suspect the problem is because I'm on Linux (case-sensitive FS) and [Shrink.Elm has been renamed recently to Shrink.elm](https://github.com/TheSeamau5/elm-shrink/commit/f6ecd39751eea2c3e1952b43cfa7be3bea31c93a). They didn't release this change yet. So if you have problems compiling this PR because of "Shrink module not found", then copying this might help.

Thanks!