### PR TITLE
Use Elm syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Examples
 ======
 
 ```elm
-{-| Parse a optional sign, succeeds with a -1 if it matches a minus `Char`, otherwise it returns 1 -}
+{-| Parse an optional sign, succeeds with a -1 if it matches a minus `Char`, otherwise it returns 1 -}
 sign : Parser Int
 sign =
     let plus = always (-1) `map` symbol '-'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ fail.
 Examples
 ======
 
-```
+```elm
 {-| Parse a optional sign, succeeds with a -1 if it matches a minus `Char`, otherwise it returns 1 -}
 sign : Parser Int
 sign =


### PR DESCRIPTION
This will show up properly highlighted on both GitHub and the Elm Package Catalog, then.