### PR TITLE
Elm 0.16 support

### DIFF
--- a/Parser.elm
+++ b/Parser.elm
@@ -222,18 +222,18 @@ end =
 
 {-| Variant of `map` that ignores the result of the parser -}
 (<$) : result -> Parser x -> Parser result
-f <$ p =
+(<$) f p =
     map (always f) p
 
 {-| Variant of `and` that ignores the result of the parser at the right -}
 (<*) : Parser result -> Parser x -> Parser result
-p <* q =
+(<*) p q =
     map always p
     |> andMap q
 
 {-| Variant of `and` that ignores the result of the parser at the left -}
 (*>) : Parser x -> Parser result -> Parser result
-p *> q =
+(*>) p q =
     map (flip always) p
     |> andMap q
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.2.1",
+    "version": "6.2.2",
     "summary": "Parser using parser combinators",
     "repository": "https://github.com/Dandandan/parser.git",
     "license": "BSD3",
@@ -15,5 +15,5 @@
         "elm-lang/core": "2.1.0 <= v < 2.2.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.15.1 <= v <= 0.16.0"
 }


### PR DESCRIPTION
Compatibility patch for Elm 0.16. Switches from infix to prefix notation when defining operators. Expands the `elm-version` to include 0.16.0 and bumps the patch version number.