### PR TITLE
Updated dependencies, dealt with removal of Browser from elm-check.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+elm-stuff/
+*.html

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.2.2",
+    "version": "6.2.3",
     "summary": "Parser using parser combinators",
     "repository": "https://github.com/Dandandan/parser.git",
     "license": "BSD3",
@@ -12,7 +12,7 @@
         "Parser.Number"
     ],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 2.2.0",
+        "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.15.1 <= v <= 0.16.0"

--- a/elm-package.json
+++ b/elm-package.json
@@ -15,5 +15,5 @@
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.15.1 <= v < 0.17.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -15,5 +15,5 @@
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.15.1 <= v <= 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -1,20 +1,15 @@
 import Check exposing (..)
-import Check.Investigator exposing ( Investigator
-                                   , investigator
-                                   , rangeInt
-                                   , float
-                                   , char
-                                   , lowerCaseChar
-                                   , upperCaseChar
-                                   , list
-                                   )
-import Check.Runner.Browser exposing (display)
+import Check.Investigator exposing (
+  Investigator, investigator, rangeInt, float,
+  char, lowerCaseChar, upperCaseChar, list
+  )
 import Parser exposing (parse, separatedBy, symbol)
 import Parser.Char as PC
 import Parser.Number as PN
 import Result.Extra exposing (isOk)
 import Shrink
 import String
+import Graphics.Element exposing (Element, show, down, flow)
 
 parserSuite =
   suite "Parser"
@@ -90,3 +85,12 @@ result =
 
 main =
     display result
+
+
+display : Evidence -> Element
+display evidence =
+  case evidence of
+  Unit unitEvidence ->
+    show unitEvidence
+  Multiple name evidences ->
+    flow down (List.map show evidences)

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -19,5 +19,5 @@
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.15.1 <= v < 0.17.0"
 }

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -19,5 +19,5 @@
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v <= 0.17.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.2.1",
+    "version": "6.2.3",
     "summary": "Parser using parser combinators (Tests)",
     "repository": "https://github.com/Dandandan/parser.git",
     "license": "BSD3",
@@ -13,10 +13,10 @@
         "Parser.Number"
     ],
     "dependencies": {
-        "TheSeamau5/elm-check": "3.2.0 <= v < 4.0.0",
-        "TheSeamau5/elm-shrink": "2.2.1 <= v < 3.0.0",
+        "NoRedInk/elm-check": "2.0.0 <= v < 3.0.0",
+        "NoRedInk/elm-shrink": "1.0.3 <= v < 2.0.0",
         "circuithub/elm-result-extra": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "2.1.0 <= v < 2.2.0",
+        "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.15.1 <= v < 0.16.0"

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -19,5 +19,5 @@
         "elm-lang/core": "2.1.0 <= v < 4.0.0",
         "maxsnew/lazy": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v <= 0.17.0"
 }


### PR DESCRIPTION
Core updated to 3.0.0.

Version bumped.

[elm-check](https://github.com/TheSeamau5/elm-check/issues/31)  and [elm-shrink](https://github.com/TheSeamau5/elm-shrink/issues/4)  are now the **NoRedInk** forks, which are under active development.

Passes tests OK.

Since Check.Runner.Browser [is gone](https://github.com/NoRedInk/elm-check/commit/2f69dfc1c1511a29f38179b26611b6f94285e49b), I added a small `display` function instead, so that test output can be examined.