### PR TITLE
migrate to elm-0.18

### DIFF
--- a/Parser.elm
+++ b/Parser.elm
@@ -67,7 +67,7 @@ parse p xs =
         [] ->
             Err "parse error"
         (x :: _) ->
-            Ok (fst x)
+            Ok (Tuple.first x)
 
 {-| Parse a `String` using a parser, return list of results -}
 parseAll : Parser result -> String -> Result String (List result)
@@ -76,7 +76,7 @@ parseAll p xs =
         [] ->
             Err "parse error"
         xs ->
-            Ok (List.map fst xs)
+            Ok (List.map Tuple.first xs)
 
 {-| Parser that always succeeds without consuming input -}
 succeed : result -> Parser result
@@ -90,8 +90,8 @@ satisfy p = Direct <| \xs ->
     case String.uncons xs of
         Nothing ->
             []
-        Just (x, xs') ->
-            if p x then [(x, xs')] else []
+        Just (x, xs1) ->
+            if p x then [(x, xs1)] else []
 
 {-| Parser that always fails -}
 empty : Parser result
@@ -122,7 +122,7 @@ choice =
 {-| Parses an optional element -}
 optional : Parser result -> result -> Parser result
 optional p x =
-    p `or` succeed x
+    or p (succeed x)
 
 {-| Parses zero or more occurences of a parser -}
 many : Parser result -> Parser (List result)
@@ -237,6 +237,6 @@ end =
     map (flip always) p
     |> andMap q
 
-infixl 4 `and`
-infixr 3 `or`
-infixl 4 `map`
+--infixl 4 and
+--infixr 3 or
+--infixl 4 map

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.2.5",
+    "version": "6.3.0",
     "summary": "Parser using parser combinators",
     "repository": "https://github.com/Dandandan/parser.git",
     "license": "BSD3",
@@ -12,8 +12,9 @@
         "Parser.Number"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/lazy": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/lazy": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Hi, here's a migration to 0.18. I did not change the andThen function, but maybe the arguments should be flipped to be consistent with other elm libraries. As new version number I chose 6.3.0, but you might want to change it and add a line to the changelog. I did not touch the tests, they seem to be outdated.